### PR TITLE
Fixed syntax error in docs for switchToLocationSettings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Android only: displays the device location settings to allow user to enable loca
 ### Example usage
 
     cordova.plugins.diagnostic.isLocationEnabled(function(enabled){
-        if(!enabled{
+        if(!enabled){
             cordova.plugins.diagnostic.switchToLocationSettings();
         }
     }, function(error){


### PR DESCRIPTION
Thanks for your plugin! This is incredibly useful for my Ionic app. 

I found a missing parenthesis in the documentation; this PR adds it back.

## Before
![screen shot 2015-07-27 at 10 08 38 am](https://cloud.githubusercontent.com/assets/8163408/8912519/1b9841d4-3448-11e5-82f6-cc024ff97609.png)

## After
![screen shot 2015-07-27 at 10 15 19 am](https://cloud.githubusercontent.com/assets/8163408/8912579/70fcf606-3448-11e5-9662-244e9364dc91.png)

