### PR TITLE
Added support for Windows 10 Mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,21 +4,22 @@ Cordova diagnostic plugin
 * [Overview](#overview)
 * [Installation](#installation)
 * [Usage](#usage)
-    * [Android and iOS](#android-and-ios)
+    * [Android, iOS and Windows 10 Mobile](#android-and-ios-and-windows)
         - [isLocationEnabled()](#islocationenabled)
         - [isWifiEnabled()](#iswifienabled)
         - [isCameraEnabled()](#iscameraenabled)
         - [isBluetoothEnabled()](#isbluetoothenabled)
-    * [Android only](#android-only)
-        - [isGpsLocationEnabled()](#isgpslocationenabled)
-        - [isNetworkLocationEnabled()](#isnetworklocationenabled)
-        - [getLocationMode()](#getlocationmode)
+    * [Android and Windows 10 Mobile](#android-and-windows)
         - [switchToLocationSettings()](#switchtolocationsettings)
         - [switchToMobileDataSettings()](#switchtomobiledatasettings)
         - [switchToBluetoothSettings()](#switchtobluetoothsettings)
         - [switchToWifiSettings()](#switchtowifisettings)
         - [setWifiState()](#setwifistate)
         - [setBluetoothState()](#setbluetoothstate)
+    * [Android only](#android-only)
+        - [isGpsLocationEnabled()](#isgpslocationenabled)
+        - [isNetworkLocationEnabled()](#isnetworklocationenabled)
+        - [getLocationMode()](#getlocationmode)
     * [iOS only](#ios-only)
         - [isLocationEnabledSetting()](#isLocationEnabledSetting)
         - [isLocationAuthorized()](#islocationauthorized)
@@ -37,12 +38,13 @@ Cordova diagnostic plugin
         - [switchToSettings()](#switchtosettings)
 * [Notes](#notes)
     * [Android permissions](#android-permissions)
+    * [Windows 10 Mobile permissions](#windows-permissions)
 * [Example project](#example-project)
 * [Credits](#credits)
 
 # Overview
 
-This Cordova/Phonegap plugin for iOS and Android is used to check the state of the following device settings:
+This Cordova/Phonegap plugin for iOS, Android and Windows 10 Mobile is used to check the state of the following device settings:
 
 - Location
 - WiFi
@@ -79,7 +81,7 @@ Add the following xml to your config.xml to use the latest version of this plugi
 
 The plugin is exposed via the `cordova.plugins.diagnostic` object and provides the following functions:
 
-## Android and iOS
+## Android, iOS and Windows 10 Mobile
 
 ### isLocationEnabled()
 
@@ -87,7 +89,7 @@ Checks if app is able to access device location.
 
     cordova.plugins.diagnostic.isLocationEnabled(successCallback, errorCallback);
 
-On iOS this returns true if both the device setting for Location Services is ON, AND the application is authorized to use location.
+On iOS and Windows 10 Mobile this returns true if both the device setting for Location Services is ON, AND the application is authorized to use location.
 When location is enabled, the locations returned are by a mixture GPS hardware, network triangulation and Wifi network IDs.
 
 On Android, this returns true if Location mode is enabled and any mode is selected (e.g. Battery saving, Device only, High accuracy)
@@ -117,7 +119,7 @@ This callback function is passed a single string parameter containing the error 
 
 Checks if Wifi is connected/enabled.
 On iOS this returns true if the device is connected to a network by WiFi.
-On Android this returns true if the WiFi setting is set to enabled.
+On Android and Windows 10 Mobile this returns true if the WiFi setting is set to enabled.
 
 On Android this requires permission `<uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />`
 
@@ -145,6 +147,7 @@ This callback function is passed a single string parameter containing the error 
 Checks if the device has a camera.
 On Android this returns true if the device has a camera.
 On iOS this returns true if both the device has a camera AND the application is authorized to use it.
+On Windows 10 Mobile this returns true if both the device has a rear-facing camera AND the application is authorized to use it.
 
     cordova.plugins.diagnostic.isCameraEnabled(successCallback, errorCallback);
 
@@ -166,7 +169,7 @@ This callback function is passed a single string parameter containing the error 
 
 ### isBluetoothEnabled()
 
-Checks if the device has Bluetooth capabilities and if so that Bluetooth is switched on (same on Android and iOS)
+Checks if the device has Bluetooth capabilities and if so that Bluetooth is switched on (same on Android, iOS and Windows 10 Mobile)
 
 On Android this requires permission `<uses-permission android:name="android.permission.BLUETOOTH" />`
 
@@ -187,6 +190,96 @@ This callback function is passed a single string parameter containing the error 
     }, function(error){
         console.error("The following error occurred: "+error);
     });
+
+## Android and Windows 10 Mobile only
+
+### switchToLocationSettings()
+
+Displays the device location settings to allow user to enable location services/change location mode.
+
+    cordova.plugins.diagnostic.switchToLocationSettings();
+
+Note: For Android, you may want to consider using the [Request Location Accuracy Plugin for Android](https://github.com/dpa99c/cordova-plugin-request-location-accuracy) to request the desired location accuracy without needing the user to manually do this on the Location Settings page.
+
+### switchToMobileDataSettings()
+
+Displays mobile settings to allow user to enable mobile data.
+
+    cordova.plugins.diagnostic.switchToMobileDataSettings();
+
+### switchToBluetoothSettings()
+
+Displays Bluetooth settings to allow user to enable Bluetooth.
+
+    cordova.plugins.diagnostic.switchToBluetoothSettings();
+
+### switchToWifiSettings()
+
+Displays WiFi settings to allow user to enable WiFi.
+
+    cordova.plugins.diagnostic.switchToWifiSettings();
+
+### setWifiState()
+
+Enables/disables WiFi on the device.
+
+    cordova.plugins.diagnostic.setWifiState(successCallback, errorCallback, state);
+
+Requires the following permissions for Android:
+
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
+    <uses-permission android:name="android.permission.CHANGE_WIFI_STATE"/>
+
+Requires the following capabilities for Windows 10 Mobile:
+
+    <DeviceCapability Name="radios" />
+
+#### Parameters
+
+- {Function} successCallback - function to call on successful setting of WiFi state
+- {Function} errorCallback - function to call on failure to set WiFi state.
+- {Boolean} state - WiFi state to set: TRUE for enabled, FALSE for disabled.
+
+
+#### Example usage
+
+    cordova.plugins.diagnostic.setWifiState(function(){
+        console.log("Wifi was enabled");
+    }, function(error){
+        console.error("The following error occurred: "+error);
+    },
+    true);
+
+### setBluetoothState()
+
+Enables/disables Bluetooth on the device.
+
+    cordova.plugins.diagnostic.setBluetoothState(successCallback, errorCallback, state);
+
+Requires the following permissions on Android:
+
+    <uses-permission android:name="android.permission.BLUETOOTH"/>
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/>
+
+Requires the following capabilities for Windows 10 Mobile:
+
+    <DeviceCapability Name="radios" />
+
+#### Parameters
+
+- {Function} successCallback - function to call on successful setting of Bluetooth state
+- {Function} errorCallback - function to call on failure to set Bluetooth state.
+- {Boolean} state - Bluetooth state to set: TRUE for enabled, FALSE for disabled.
+
+
+#### Example usage
+
+    cordova.plugins.diagnostic.setBluetoothState(function(){
+        console.log("Bluetooth was enabled");
+    }, function(error){
+        console.error("The following error occurred: "+error);
+    },
+    true);
 
 ## Android only
 
@@ -272,87 +365,6 @@ This callback function is passed a single string parameter containing the error 
     }, function(error){
         console.error("The following error occurred: "+error);
     });
-
-### switchToLocationSettings()
-
-Displays the device location settings to allow user to enable location services/change location mode.
-
-    cordova.plugins.diagnostic.switchToLocationSettings();
-
-Note: You may want to consider using the [Request Location Accuracy Plugin for Android](https://github.com/dpa99c/cordova-plugin-request-location-accuracy) to request the desired location accuracy without needing the user to manually do this on the Location Settings page.
-
-### switchToMobileDataSettings()
-
-Displays mobile settings to allow user to enable mobile data.
-
-    cordova.plugins.diagnostic.switchToMobileDataSettings();
-
-### switchToBluetoothSettings()
-
-Displays Bluetooth settings to allow user to enable Bluetooth.
-
-    cordova.plugins.diagnostic.switchToBluetoothSettings();
-
-
-### switchToWifiSettings()
-
-Displays WiFi settings to allow user to enable WiFi.
-
-    cordova.plugins.diagnostic.switchToWifiSettings();
-
-### setWifiState()
-
-Enables/disables WiFi on the device.
-
-    cordova.plugins.diagnostic.setWifiState(successCallback, errorCallback, state);
-
-Requires the following permissions:
-
-    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
-    <uses-permission android:name="android.permission.CHANGE_WIFI_STATE"/>
-
-#### Parameters
-
-- {Function} successCallback - function to call on successful setting of WiFi state
-- {Function} errorCallback - function to call on failure to set WiFi state.
-- {Boolean} state - WiFi state to set: TRUE for enabled, FALSE for disabled.
-
-
-#### Example usage
-
-    cordova.plugins.diagnostic.setWifiState(function(){
-        console.log("Wifi was enabled");
-    }, function(error){
-        console.error("The following error occurred: "+error);
-    },
-    true);
-
-### setBluetoothState()
-
-Enables/disables Bluetooth on the device.
-
-    cordova.plugins.diagnostic.setBluetoothState(successCallback, errorCallback, state);
-
-Requires the following permissions:
-
-    <uses-permission android:name="android.permission.BLUETOOTH"/>
-    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/>
-
-#### Parameters
-
-- {Function} successCallback - function to call on successful setting of Bluetooth state
-- {Function} errorCallback - function to call on failure to set Bluetooth state.
-- {Boolean} state - Bluetooth state to set: TRUE for enabled, FALSE for disabled.
-
-
-#### Example usage
-
-    cordova.plugins.diagnostic.setBluetoothState(function(){
-        console.log("Bluetooth was enabled");
-    }, function(error){
-        console.error("The following error occurred: "+error);
-    },
-    true);
 
 ## iOS only
 
@@ -688,6 +700,15 @@ These permissions will not be set by this plugin, to avoid asking for unnecessar
 Instead, you can add these permissions as necessary, depending what functions in the plugin you decide to use.
 
 You can add these permissions either by manually editing the AndroidManifest.xml if `/platform/android/`, or define them in the config.xml and apply them using the [cordova-custom-config](https://github.com/dpa99c/cordova-custom-config) plugin.
+
+## Windows 10 Mobile permissions
+
+Some of functions offered by this plugin require specific permissions to be set in the package.windows10.appxmanifest. Where additional permissions are needed, they are listed alongside the function that requires them.
+
+These permissions will not be set by this plugin, to avoid asking for unnecessary permissions in your app, in the case that you do not use a particular part of the plugin.
+Instead, you can add these permissions as necessary, depending what functions in the plugin you decide to use.
+
+You can add these permissions by manually editing the package.windows10.appxmanifest if `/platform/windows/`.
 
 # Example project
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova.plugins.diagnostic"
-    version="2.2.3">
+    version="2.2.4">
 
     <name>Diagnostic</name>
     <description>Cordova/Phonegap plugin to check the state of Location/WiFi/Camera/Bluetooth device settings.</description>
@@ -36,17 +36,33 @@
         <framework src="Photos.framework" />
     </platform>
 
-    <!-- android -->
-    <platform name="android">
-        <config-file target="config.xml" parent="/*">
-            <feature name="Diagnostic" >
-                <param name="android-package" value="cordova.plugins.Diagnostic"/>
-            </feature>
-        </config-file>
+	<!-- android -->
+	<platform name="android">
+		<config-file target="config.xml" parent="/*">
+			<feature name="Diagnostic" >
+				<param name="android-package" value="cordova.plugins.Diagnostic"/>
+			</feature>
+		</config-file>
 
-        <js-module src="www/android/diagnostic.js" name="Diagnostic">
-            <clobbers target="cordova.plugins.diagnostic" />
-        </js-module>
-        <source-file src="src/android/Diagnostic.java" target-dir="src/cordova/plugins" />
-    </platform>
+		<js-module src="www/android/diagnostic.js" name="Diagnostic">
+			<clobbers target="cordova.plugins.diagnostic" />
+		</js-module>
+		<source-file src="src/android/Diagnostic.java" target-dir="src/cordova/plugins" />
+	</platform>
+
+	<!-- windows -->
+	<platform name="windows">
+		<config-file target="config.xml" parent="/*">
+			<feature name="Diagnostic" >
+				<param name="windows-package" value="cordova.plugins.Diagnostic"/>
+			</feature>
+		</config-file>
+
+		<js-module src="www/windows/diagnostic.js" name="Diagnostic">
+			<clobbers target="cordova.plugins.diagnostic" />
+		</js-module>
+		<js-module src="src/windows/diagnosticProxy.js" name="diagnosticProxy">
+			<merges target="" />
+		</js-module>
+	</platform>
 </plugin>

--- a/src/windows/diagnosticProxy.js
+++ b/src/windows/diagnosticProxy.js
@@ -1,0 +1,236 @@
+/**
+ *  Diagnostic plugin for Windows 10 Universal
+ *
+ *  Copyright (c) 2015 Next Wave Software, Inc.
+**/
+cordova.commandProxy.add("Diagnostic", {
+
+    /**
+     * Checks if location is enabled.
+     *
+     * @param {Function} successCallback - The callback which will be called when diagnostic is successful. 
+     * This callback function is passed a single boolean parameter with the diagnostic result.
+     * @param {Function} errorCallback -  The callback which will be called when diagnostic encounters an error.
+     *  This callback function is passed a single string parameter containing the error message.
+     */
+    // exec(win, fail, 'Diagnostic', 'isLocationEnabled', []);
+    isLocationEnabled: function (successCallback, errorCallback) {
+
+        Windows.Devices.Geolocation.Geolocator.requestAccessAsync().done(
+            function (accessStatus) {
+                var isEnabled = false;
+                var isError = false;
+                switch (accessStatus) {
+                    case Windows.Devices.Geolocation.GeolocationAccessStatus.allowed:
+                        isEnabled = true;
+                        break;
+                    case Windows.Devices.Geolocation.GeolocationAccessStatus.denied:
+                        isEnabled = false;
+                        break;
+                    case Windows.Devices.Geolocation.GeolocationAccessStatus.unspecified:
+                        isError = true;
+                        break;
+                }
+                if (!isError)
+                    successCallback(isEnabled);
+                else
+                    errorCallback("Unspecified error");
+            },
+            function (error) {
+                errorCallback(error);
+            }
+        );
+    },
+
+    /**
+     * Checks if bluetooth/wifi is enabled.
+     *
+     * @param {Function} successCallback - The callback which will be called when diagnostic is successful. 
+     * This callback function is passed a single boolean parameter with the diagnostic result.
+     * @param {Function} errorCallback -  The callback which will be called when diagnostic encounters an error.
+     *  This callback function is passed a single string parameter containing the error message.
+     * @param {String} radioToCheck - "bluetooth" or "wifi".
+     */
+    // exec(win, fail, 'Diagnostic', 'isRadioEnabled', [bluetooth/wifi]);
+    isRadioEnabled: function (successCallback, errorCallback, radioToCheck) {
+
+        Windows.Devices.Radios.Radio.getRadiosAsync().done(
+            function (radioList) {
+                var radioKind = (radioToCheck == "bluetooth") ? Windows.Devices.Radios.RadioKind.bluetooth : Windows.Devices.Radios.RadioKind.wiFi;
+                var isEnabled = false;
+                for (var i = 0; i < radioList.length; i++) {
+                    if ((radioList[i].kind == radioKind)
+                        && (radioList[i].state == Windows.Devices.Radios.RadioState.on)) {
+                        isEnabled = true;
+                        break;
+                    }
+                }
+                successCallback(isEnabled);
+            },
+            function (error) {
+                errorCallback(error);
+            }
+        );
+    },
+
+    /**
+     * Checks if camera is enabled.
+     *
+     * @param {Function} successCallback - The callback which will be called when diagnostic is successful. 
+     * This callback function is passed a single boolean parameter with the diagnostic result.
+     * @param {Function} errorCallback -  The callback which will be called when diagnostic encounters an error.
+     *  This callback function is passed a single string parameter containing the error message.
+     */
+    // exec(win, fail, 'Diagnostic', 'isCameraEnabled', []);
+    isCameraEnabled: function (successCallback, errorCallback) {
+
+        Windows.Devices.Enumeration.DeviceInformation.findAllAsync(Windows.Devices.Enumeration.DeviceClass.videoCapture).then(
+            function (deviceList) {
+                var isEnabled = false;
+                for (var i = 0; i < deviceList.length; i++) {
+                    if ((deviceList[i].enclosureLocation != null) && (deviceList[i].enclosureLocation.panel === Windows.Devices.Enumeration.Panel.back)) {
+                        isEnabled = true;
+                        break;
+                    }
+                }
+                successCallback(isEnabled);
+            },
+            function (error) {
+                errorCallback(error);
+            }
+        );
+    },
+
+    /**
+     * Display the location services settings page.
+     */
+    // exec(null, null, 'Diagnostic', 'switchToLocationSettings', []);
+    switchToLocationSettings: function () {
+
+        var uri = new Windows.Foundation.Uri("ms-settings:privacy-location");
+        Windows.System.Launcher.launchUriAsync(uri);
+    },
+
+    /**
+     * Display the mobile data settings page.
+     */
+    // exec(null, null, 'Diagnostic', 'switchToMobileDataSettings', []);
+    switchToMobileDataSettings: function () {
+
+        var uri = new Windows.Foundation.Uri("ms-settings:datausage");
+        Windows.System.Launcher.launchUriAsync(uri);
+    },
+
+    /**
+     * Display the wifi settings page.
+     */
+    // exec(null, null, 'Diagnostic', 'switchToWifiSettings', []);
+    switchToWifiSettings: function () {
+
+        var uri = new Windows.Foundation.Uri("ms-settings-wifi:");
+        Windows.System.Launcher.launchUriAsync(uri);
+    },
+
+    /**
+     * Display the bluetooth settings page.
+     */
+    // exec(null, null, 'Diagnostic', 'switchToBluetoothSettings', []);
+    switchToBluetoothSettings: function () {
+
+        // Mike says: According to the docs, "ms-settings-bluetooth:" is the correct URI to use
+        // to take the user directly to the Bluetooth page in the mobile settings app, but as of 10/9/2015
+        // it does not work (we just get back "false" in the success callback). So,
+        // using the desktop settings URI until this gets fixed, which takes the user to the
+        // "which of these settings are you interested in?" page.
+        var uri = new Windows.Foundation.Uri("ms-settings:bluetooth");
+        Windows.System.Launcher.launchUriAsync(uri);
+    },
+
+    /**
+     * Enables/disables WiFi or Bluetooth on the device.
+     *
+     * @param {Function} successCallback - function to call on successful setting of radio state
+     * @param {Function} errorCallback - function to call on failure to set radio state.
+     * This callback function is passed a single string parameter containing the error message.
+     * @param {String} radioToSet - "bluetooth" or "wifi".
+     * @param {Boolean} state - WiFi state to set: TRUE for enabled, FALSE for disabled.
+     */
+    // exec(win, fil, 'Diagnostic', 'setRadioState', [bluetooth/wifi, true/false]);
+    setRadioState: function (successCallback, errorCallback, args) {
+
+        var radioToSet = args[0];
+        var state = args[1];
+
+        // Check the return code from Radio.requestAccessAsync() and Radio.setStateAsync() 
+        // calls below, return "Ok" if successful, error message if not.
+        function checkRadioAccessError(accessStatus) {
+            var msgOut = "";
+            switch (accessStatus) {
+                case Windows.Devices.Radios.RadioAccessStatus.allowed:
+                    msgOut = "Ok";
+                    break;
+                case Windows.Devices.Radios.RadioAccessStatus.deniedByUser:
+                    msgOut = "Access denied by user";
+                    break;
+                case Windows.Devices.Radios.RadioAccessStatus.deniedBySystem:
+                    msgOut = "Access denied by system";
+                    break;
+                case Windows.Devices.Radios.RadioAccessStatus.unspecified:
+                default:
+                    msgOut = "Access denied, unspecified reason";
+                    break;
+            }
+            return (msgOut);
+        }
+
+        // Get the requested radio
+        var radioKind = (radioToSet == "bluetooth") ? Windows.Devices.Radios.RadioKind.bluetooth : Windows.Devices.Radios.RadioKind.wiFi;
+        Windows.Devices.Radios.Radio.getRadiosAsync().done(
+            function (radioList) {
+                var radio = null;
+                for (var i = 0; i < radioList.length; i++) {
+                    if (radioList[i].kind == radioKind) {
+                        radio = radioList[i];
+                        break;
+                    }
+                }
+                if (radio == null) {
+                    errorCallback("Device not found");
+                    return;
+                }
+
+                // Get access to the radio
+                Windows.Devices.Radios.Radio.requestAccessAsync().done(
+                    function (accessStatus) {
+                        var resultMsg = checkRadioAccessError(accessStatus);
+                        if (resultMsg != "Ok") {
+                            errorCallback(resultMsg);
+                            return;
+                        }
+
+                        // Set the state of the radio
+                        var radioState = (state) ? Windows.Devices.Radios.RadioState.on : Windows.Devices.Radios.RadioState.off;
+                        radio.setStateAsync(radioState).done(
+                            function (accessStatus) {
+                                var resultMsg = checkRadioAccessError(accessStatus);
+                                if (resultMsg == "Ok")
+                                    successCallback();
+                                else
+                                    errorCallback(resultMsg);
+                            },
+                            function (error) {
+                                errorCallback(error);
+                            }
+                        );
+                    },
+                    function (error) {
+                        errorCallback(error);
+                    }
+                );
+            },
+            function (error) {
+                errorCallback(error);
+            }
+        );
+    },
+});

--- a/www/windows/diagnostic.js
+++ b/www/windows/diagnostic.js
@@ -1,0 +1,149 @@
+/**
+ *  Diagnostic plugin for Windows 10 Universal
+ *
+ *  Copyright (c) Next Wave Software, Inc.
+**/
+var Diagnostic = function () { };
+
+/**
+ * Checks if location is enabled.
+ *
+ * @param {Function} successCallback - The callback which will be called when diagnostic is successful. 
+ * This callback function is passed a single boolean parameter with the diagnostic result.
+ * @param {Function} errorCallback -  The callback which will be called when diagnostic encounters an error.
+ *  This callback function is passed a single string parameter containing the error message.
+ */
+Diagnostic.prototype.isLocationEnabled = function (successCallback, errorCallback) {
+    return cordova.exec(successCallback,
+		errorCallback,
+		'Diagnostic',
+		'isLocationEnabled',
+		[]);
+};
+
+/**
+ * Checks if Wifi is enabled.
+ * On Android this returns true if the WiFi setting is set to enabled.
+ *
+ * @param {Function} successCallback -  The callback which will be called when diagnostic is successful.
+ * This callback function is passed a single boolean parameter with the diagnostic result.
+ * @param {Function} errorCallback -  The callback which will be called when diagnostic encounters an error.
+ *  This callback function is passed a single string parameter containing the error message.
+ */
+Diagnostic.prototype.isWifiEnabled = function (successCallback, errorCallback) {
+    return cordova.exec(successCallback,
+		errorCallback,
+		'Diagnostic',
+		'isRadioEnabled',
+		['wifi']);
+};
+
+/**
+ * Checks if Bluetooth is enabled
+ *
+ * @param {Function} successCallback -  The callback which will be called when diagnostic is successful.
+ * This callback function is passed a single boolean parameter with the diagnostic result.
+ * @param {Function} errorCallback -  The callback which will be called when diagnostic encounters an error.
+ *  This callback function is passed a single string parameter containing the error message.
+ */
+Diagnostic.prototype.isBluetoothEnabled = function (successCallback, errorCallback) {
+    return cordova.exec(successCallback,
+		errorCallback,
+		'Diagnostic',
+		'isRadioEnabled',
+		['bluetooth']);
+};
+
+/**
+ * Checks if camera exists.
+ *
+ * @param {Function} successCallback -  The callback which will be called when diagnostic is successful.
+ * This callback function is passed a single boolean parameter with the diagnostic result.
+ * @param {Function} errorCallback -  The callback which will be called when diagnostic encounters an error.
+ *  This callback function is passed a single string parameter containing the error message.
+ */
+Diagnostic.prototype.isCameraEnabled = function (successCallback, errorCallback) {
+    return cordova.exec(successCallback,
+		errorCallback,
+		'Diagnostic',
+		'isCameraEnabled',
+		[]);
+};
+
+/**
+ * Switches to the Location page in the Settings app
+ */
+Diagnostic.prototype.switchToLocationSettings = function () {
+    return cordova.exec(null,
+		null,
+		'Diagnostic',
+		'switchToLocationSettings',
+		[]);
+};
+
+/**
+* Switches to the Mobile Data page in the Settings app
+*/
+Diagnostic.prototype.switchToMobileDataSettings = function () {
+    return cordova.exec(null,
+		null,
+		'Diagnostic',
+		'switchToMobileDataSettings',
+		[]);
+};
+
+/**
+ * Switches to the Bluetooth page in the Settings app
+ */
+Diagnostic.prototype.switchToBluetoothSettings = function () {
+    return cordova.exec(null,
+		null,
+		'Diagnostic',
+		'switchToBluetoothSettings',
+		[]);
+};
+
+/**
+ * Switches to the WiFi page in the Settings app
+ */
+Diagnostic.prototype.switchToWifiSettings = function () {
+    return cordova.exec(null,
+		null,
+		'Diagnostic',
+		'switchToWifiSettings',
+		[]);
+};
+
+/**
+ * Enables/disables WiFi on the device.
+ *
+ * @param {Function} successCallback - function to call on successful setting of WiFi state
+ * @param {Function} errorCallback - function to call on failure to set WiFi state.
+ * This callback function is passed a single string parameter containing the error message.
+ * @param {Boolean} state - WiFi state to set: TRUE for enabled, FALSE for disabled.
+ */
+Diagnostic.prototype.setWifiState = function (successCallback, errorCallback, state) {
+    return cordova.exec(successCallback,
+		errorCallback,
+		'Diagnostic',
+		'setRadioState',
+		['wifi', state]);
+};
+
+/**
+ * Enables/disables Bluetooth on the device.
+ *
+ * @param {Function} successCallback - function to call on successful setting of Bluetooth state
+ * @param {Function} errorCallback - function to call on failure to set Bluetooth state.
+ * This callback function is passed a single string parameter containing the error message.
+ * @param {Boolean} state - Bluetooth state to set: TRUE for enabled, FALSE for disabled.
+ */
+Diagnostic.prototype.setBluetoothState = function (successCallback, errorCallback, state) {
+    return cordova.exec(successCallback,
+		errorCallback,
+		'Diagnostic',
+		'setRadioState',
+		['bluetooth', state]);
+};
+
+module.exports = new Diagnostic();


### PR DESCRIPTION
This branch adds support for Windows 10 Mobile. I've updated the README with the Windows particulars, but basically it has all of the functionality of the Android version except for isGpsLocationEnabled(), isNetworkLocationEnabled() & getLocationMode(), which don't really make sense on Windows since it uses a secret-sauce combination of GPS/Network/"undisclosed"/etc. techniques to report the location. The only known issue at this time is that switchToBluetoothSettings() takes the user to the All Settings page of the Settings app rather than to the Bluetooth page. I believe there's a problem with the URI for that page and have so noted it in the code. Microsoft's documentation states that it's "ms-settings-bluetooth:" for Windows 10 Mobile, "ms-settings:bluetooth" for Windows 10 Desktop [so much for "Windows Universal Apps" BTW :)], but if I try to hit that URI the OS calls the onSuccess callback with a value of false (as opposed to the normal response of "I don't know what that is"). It's still early days for Windows 10 Mobile, so I will wait and see if/when more developers complain about this and patch it when able.
