### PR TITLE
Fixed requestCameraAuthorization returning DENIED_ALWAYS when access is granted

### DIFF
--- a/www/android/diagnostic.js
+++ b/www/android/diagnostic.js
@@ -619,7 +619,6 @@ var Diagnostic = (function(){
 			successCallback(combineCameraStatuses(statuses));
 		}
 		Diagnostic.requestRuntimePermissions(onSuccess, errorCallback, [
-			Diagnostic.runtimePermission.CAMERA,
 			Diagnostic.runtimePermission.READ_EXTERNAL_STORAGE
 		]);
 	};
@@ -636,7 +635,6 @@ var Diagnostic = (function(){
 			successCallback(combineCameraStatuses(statuses));
 		}
 		Diagnostic.getPermissionsAuthorizationStatus(onSuccess, errorCallback, [
-			Diagnostic.runtimePermission.CAMERA,
 			Diagnostic.runtimePermission.READ_EXTERNAL_STORAGE
 		]);
 	};


### PR DESCRIPTION
I didn't understand why my app reported not having access to camera since i did give it access and it was actually taking pictures.

Turns out, android M doesn't care much about camera but only about external storage access.
Removing references to camera access fixed my problem.

I tried asking only for camera (and not for storage) and nothing ever happened (no prompt, no new authorization entries in app details).

Also tested on lollipop (5.1.1) and kitkat (4.4.2) and it works fine.