### PR TITLE
Prevent Bluetooth Exception On Initialization

### DIFF
--- a/src/android/Diagnostic.java
+++ b/src/android/Diagnostic.java
@@ -57,6 +57,7 @@ import android.provider.Settings;
 import android.net.wifi.WifiManager;
 
 import android.support.v4.app.ActivityCompat;
+import java.lang.SecurityException;
 
 /**
  * Diagnostic plugin implementation for Android
@@ -211,15 +212,19 @@ public class Diagnostic extends CordovaPlugin{
      */
     public void initialize(CordovaInterface cordova, CordovaWebView webView) {
         instance = this;
-
-        if(this.hasBluetoothSupport()){
-            if(this.isBluetoothEnabled()){
-                bluetoothState = BLUETOOTH_STATE_POWERED_ON;
-            }else{
-                bluetoothState = BLUETOOTH_STATE_POWERED_OFF;
-            }
-
+        try {
+               if(this.hasBluetoothSupport()){
+                      if(this.isBluetoothEnabled()){
+                              bluetoothState = BLUETOOTH_STATE_POWERED_ON;
+                      } else{
+                              bluetoothState = BLUETOOTH_STATE_POWERED_OFF;
+                      }
+               }
         }
+        catch(SecurityException e) {
+               bluetoothState = BLUETOOTH_STATE_POWERED_OFF;
+        }
+       }
 
         locationManager = (LocationManager) this.cordova.getActivity().getSystemService(Context.LOCATION_SERVICE);
         super.initialize(cordova, webView);


### PR DESCRIPTION
We were having a problem where this plugin would fail on initialization with the below stack trace. I narrowed it down to this block. By wrapping this in a block with fail it seems to be fine.

```System.err: java.lang.SecurityException: Need BLUETOOTH permission: Neither user 10119 nor current process has android.permission.BLUETOOTH.
05-26 16:13:58.271 26276 26396 W System.err:     at android.os.Parcel.readException(Parcel.java:1620)
05-26 16:13:58.271 26276 26396 W System.err:     at android.os.Parcel.readException(Parcel.java:1573)
05-26 16:13:58.271 26276 26396 W System.err:     at android.bluetooth.IBluetooth$Stub$Proxy.isEnabled(IBluetooth.java:848)
05-26 16:13:58.271 26276 26396 W System.err:     at android.bluetooth.BluetoothAdapter.isEnabled(BluetoothAdapter.java:610)
05-26 16:13:58.271 26276 26396 W System.err:     at cordova.plugins.Diagnostic.isBluetoothEnabled(Diagnostic.java:378)
05-26 16:13:58.271 26276 26396 W System.err:     at cordova.plugins.Diagnostic.initialize(Diagnostic.java:216)
05-26 16:13:58.271 26276 26396 W System.err:     at org.apache.cordova.CordovaPlugin.privateInitialize(CordovaPlugin.java:57)
05-26 16:13:58.271 26276 26396 W System.err:     at org.apache.cordova.PluginManager.getPlugin(PluginManager.java:172)
05-26 16:13:58.271 26276 26396 W System.err:     at org.apache.cordova.PluginManager.exec(PluginManager.java:123)
05-26 16:13:58.271 26276 26396 W System.err:     at org.apache.cordova.CordovaBridge.jsExec(CordovaBridge.java:59)
05-26 16:13:58.271 26276 26396 W System.err:     at org.apache.cordova.engine.SystemExposedJsApi.exec(SystemExposedJsApi.java:41)
05-26 16:13:58.271 26276 26396 W System.err:     at org.chromium.base.SystemMessageHandler.nativeDoRunLoopOnce(Native Method)
05-26 16:13:58.271 26276 26396 W System.err:     at org.chromium.base.SystemMessageHandler.handleMessage(SystemMessageHandler.java:39)
05-26 16:13:58.271 26276 26396 W System.err:     at android.os.Handler.dispatchMessage(Handler.java:102)
05-26 16:13:58.271 26276 26396 W System.err:     at android.os.Looper.loop(Looper.java:148)
05-26 16:13:58.271 26276 26396 W System.err:     at android.os.HandlerThread.run(HandlerThread.java:61)
05-26 16:14:00.000  3029  5367 V AlarmManager: sending alarm {12bec61 type 3 ​*alarm*​:android.intent.action.TIME_TICK}```