### PR TITLE
Fixed small bug in notifyLocationStateChange method fro android

### DIFF
--- a/src/android/Diagnostic.java
+++ b/src/android/Diagnostic.java
@@ -362,7 +362,7 @@ public class Diagnostic extends CordovaPlugin{
         try {
             String currentMode = currentLocationMode;
             String newMode = getLocationModeName();
-            if(!currentMode.equals(newMode)){
+            if(!newMode.equals(currentMode)){
                 Log.d(TAG, "Location mode change to: " + getLocationModeName());
                 executeGlobalJavascript("_onLocationStateChange(\"" + getLocationModeName() +"\");");
             }


### PR DESCRIPTION
When app is run, currentLocationMode == null. 
If user in this case change location (turn on or off) that (currentMode.equals(newMode) line 365) throw exception and don't execute callback to JS. 
I replace this condition on newMode.equals(currentMode). In this situation newMode will has value always.