### PR TITLE
Fix #118

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -66,6 +66,10 @@
         <config-file target="*-Info.plist" parent="NSContactsUsageDescription">
           <string>This app requires contacts access to function properly.</string>
         </config-file>
+	    
+    	<config-file target="*-Info.plist" parent="Privacy - Contacts Usage Description">
+          <string>This app requires contacts access to function properly.</string>
+        </config-file>
 
         <config-file target="*-Info.plist" parent="NSRemindersUsageDescription">
             <string>This app requires reminders access to function properly.</string>


### PR DESCRIPTION
Add `Privacy - Contacts Usage Description` for iOS 10