### PR TITLE
Android dependencies - Always use latest

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -98,8 +98,8 @@
             </feature>
         </config-file>
 
-        <framework src="com.android.support:support-v4:25.+" />
-        <framework src="com.android.support:appcompat-v7:25.+" />
+        <framework src="com.android.support:support-v4:+" />
+        <framework src="com.android.support:appcompat-v7:+" />
 
         <js-module src="www/android/diagnostic.js" name="Diagnostic">
             <clobbers target="cordova.plugins.diagnostic" />


### PR DESCRIPTION
Most Android plugins / SDKs depend on `com.android.support` and having mismatched versions creates a number of issues.
To avoid conflicts with other Cordova plugins most plugins have opted to use '+' which will always use the latest available.
Ideally it would be better to define a version range however Gradle has some resolution limitations and issues.