### PR TITLE
Camera module: de-nest config-file & framework entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+**v4.0.5**
+* Ensure complete camera module inclusion and default Info.plist strings on iOS
+
 **v4.0.4**
 * Ensure all Android code entry points are handled in try/catch blocks to prevent app crashes by unhandled exceptions.
 * Enable the `types` parameter for `requestRemoteNotificationsAuthorization` to be omitted (rather than requiring empty object). Fixes [#286](https://github.com/dpa99c/cordova-diagnostic-plugin/issues/286).

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "version": "4.0.4",
+    "version": "4.0.5",
     "name": "cordova.plugins.diagnostic",
     "cordova_name": "Diagnostic",
     "description": "Cordova/Phonegap plugin to check the state of Location/WiFi/Camera/Bluetooth device settings.",

--- a/plugin.xml
+++ b/plugin.xml
@@ -104,22 +104,22 @@
                 <param name="ios-package" value="Diagnostic_Camera" />
                 <param name="onload" value="true" />
             </feature>
-
-            <framework src="Photos.framework" />
-            <framework src="AVFoundation.framework" />
-
-            <config-file target="*-Info.plist" parent="NSCameraUsageDescription">
-                <string>This app requires camera access to function properly.</string>
-            </config-file>
-
-            <config-file target="*-Info.plist" parent="NSPhotoLibraryUsageDescription">
-                <string>This app requires photo library access to function properly.</string>
-            </config-file>
         </config-file>
 
         <js-module src="www/ios/diagnostic.camera.js" name="Diagnostic_Camera">
             <merges target="cordova.plugins.diagnostic.camera" />
         </js-module>
+
+        <framework src="Photos.framework" />
+        <framework src="AVFoundation.framework" />
+
+        <config-file target="*-Info.plist" parent="NSCameraUsageDescription">
+            <string>This app requires camera access to function properly.</string>
+        </config-file>
+
+        <config-file target="*-Info.plist" parent="NSPhotoLibraryUsageDescription">
+            <string>This app requires photo library access to function properly.</string>
+        </config-file>
 
         <header-file src="src/ios/Diagnostic_Camera.h" />
         <source-file src="src/ios/Diagnostic_Camera.m" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova.plugins.diagnostic"
-    version="4.0.4">
+    version="4.0.5">
 
     <name>Diagnostic</name>
     <description>Cordova/Phonegap plugin to check the state of Location/WiFi/Camera/Bluetooth device settings.</description>


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

<!-- Fill out the relevant sections below and delete irrelevant sections. -->

## What is the purpose of this PR?
<!-- Describe any current behavior that you are modifying, or link to a relevant issue. -->
<!-- Describe the new behaviour added/modified and its purpose. -->
After upgrading from `3.7.3` to `4.x`, my iOS builds were missing the Camera privacy plist entries (e.g. `NSPhotoLibraryUsageDescription`).

It appears that for the iOS camera module, the `<framework>` and `<config-file target="*-Info.plist">` elements were accidentally nested inside the `<config-file target="config.xml">` element. This PR simply relocates them after the `<js-module>` element (matching the pattern of other iOS modules).

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

Technically, I should probably be either overriding the default plist values, or disabling the Camera module, since I don't use it, but this change gets my builds working, and seems to be the intention of @dpa99c. Probably just a quick error in the `4.x` refactors.

Thanks for reading!