### PR TITLE
Fix error in hasBluetoothSupport()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1419,7 +1419,7 @@ Platforms: Android
 Checks if the device has Bluetooth capabilities.
 See http://developer.android.com/guide/topics/connectivity/bluetooth.html.
 
-    cordova.plugins.diagnostic.hasBluetoothLESupport(successCallback, errorCallback);
+    cordova.plugins.diagnostic.hasBluetoothSupport(successCallback, errorCallback);
 
 #### Parameters
 


### PR DESCRIPTION
Change `cordova.plugins.diagnostic.hasBluetoothLESupport(successCallback, errorCallback);` for `    cordova.plugins.diagnostic.hasBluetoothSupport(successCallback, errorCallback);` as specified in #### Example usage

## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Code style update (formatting, local variables)
- [x] Documentation  changes
- [ ] Other... Please describe:

<!-- Fill out the relevant sections below and delete irrelevant sections. -->


## What is the purpose of this PR?
Change small error in the documentation for hasBluetoothSupport

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
