### PR TITLE
Specify permissions for context-registered broadcast receivers

### DIFF
--- a/src/android/Diagnostic_Bluetooth.java
+++ b/src/android/Diagnostic_Bluetooth.java
@@ -31,6 +31,7 @@ import android.content.pm.PackageManager;
 import android.os.Build;
 import android.provider.Settings;
 import android.util.Log;
+import android.Manifest;
 
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaInterface;
@@ -121,7 +122,7 @@ public class Diagnostic_Bluetooth extends CordovaPlugin{
         diagnostic = Diagnostic.getInstance();
 
         try {
-            diagnostic.applicationContext.registerReceiver(bluetoothStateChangeReceiver, new IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED));
+            diagnostic.applicationContext.registerReceiver(bluetoothStateChangeReceiver, new IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED), Manifest.permission.BLUETOOTH, null);
             currentBluetoothState = getBluetoothState();
         }catch(Exception e){
             diagnostic.logWarning("Unable to register Bluetooth state change receiver: " + e.getMessage());

--- a/src/android/Diagnostic_Location.java
+++ b/src/android/Diagnostic_Location.java
@@ -34,6 +34,7 @@ import android.content.IntentFilter;
 import android.location.LocationManager;
 import android.os.Build;
 import android.util.Log;
+import android.Manifest;
 
 import android.content.Context;
 import android.content.Intent;
@@ -107,7 +108,7 @@ public class Diagnostic_Location extends CordovaPlugin{
         diagnostic = Diagnostic.getInstance();
 
         try {
-            diagnostic.applicationContext.registerReceiver(locationProviderChangedReceiver, new IntentFilter(LocationManager.PROVIDERS_CHANGED_ACTION));
+            diagnostic.applicationContext.registerReceiver(locationProviderChangedReceiver, new IntentFilter(LocationManager.PROVIDERS_CHANGED_ACTION), Manifest.permission.ACCESS_COARSE_LOCATION, null);
             locationManager = (LocationManager) this.cordova.getActivity().getSystemService(Context.LOCATION_SERVICE);
         }catch(Exception e){
             diagnostic.logWarning("Unable to register Location Provider Change receiver: " + e.getMessage());

--- a/src/android/Diagnostic_NFC.java
+++ b/src/android/Diagnostic_NFC.java
@@ -28,6 +28,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.provider.Settings;
 import android.util.Log;
+import android.Manifest;
 
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaInterface;
@@ -112,7 +113,7 @@ public class Diagnostic_NFC extends CordovaPlugin{
         diagnostic = Diagnostic.getInstance();
 
         try {
-            diagnostic.applicationContext.registerReceiver(NFCStateChangedReceiver, new IntentFilter(NfcAdapter.ACTION_ADAPTER_STATE_CHANGED));
+            diagnostic.applicationContext.registerReceiver(NFCStateChangedReceiver, new IntentFilter(NfcAdapter.ACTION_ADAPTER_STATE_CHANGED), Manifest.permission.NFC, null);
             nfcManager = (NfcManager) diagnostic.applicationContext.getSystemService(Context.NFC_SERVICE);
         }catch(Exception e){
             diagnostic.logWarning("Unable to register NFC state change receiver: " + e.getMessage());


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [x] Other... Please describe:

<!-- Fill out the relevant sections below and delete irrelevant sections. -->

## PR Checklist
For bug fixes / features, please check if your PR fulfills the following requirements:

- [x] Testing has been carried out for the changes have been added
- [x] Regression testing has been carried out for existing functionality
- [x] Docs have been added / updated

## What is the purpose of this PR?
When this plugin is scanned by NowSecure, the following is reported:
> Android apps can dynamically register broadcast receivers and specify permissions to restrict access to them. Broadcast receivers that are registered without specifying any permissions can potentially leak sensitive info to all other applications on the device. This test detects any context-registered broadcast receivers that have not been protected with permissions.

Link to relevant CWE: https://cwe.mitre.org/data/definitions/925.html

To remedy this, permissions have to be defined for the broadcast receivers registered by the Bluetooth, Location, and NFC components.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing plugin versions. -->

## What testing has been done on the changes in the PR?
<!-- e.g. if an example project exists for this plugin, has it been updated to test the new functionality? -->

## What testing has been done on existing functionality?
<!-- e.g. if an example project exists for this plugin, has been it been tested to ensure no regression bugs have been introduced? -->

## Other information