### PR TITLE
Add ability to open notification settings on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -2607,6 +2607,17 @@ Requests remote notifications authorization for the application.
         omitRegistration: false
     });
 
+
+### switchToNotificationSettings()
+
+Platforms: Android
+
+Open notification settings for your app
+
+On Android versions lower than O, this will open the same page as `switchToSettings()`.
+
+    cordova.plugins.diagnostic.switchToNFCSettings();
+
 ## Microphone module
 
 Purpose: Microphone permission to record audio.

--- a/src/android/Diagnostic_Notifications.java
+++ b/src/android/Diagnostic_Notifications.java
@@ -144,7 +144,7 @@ public class Diagnostic_Notifications extends CordovaPlugin{
         } else {
             settingsIntent.setAction(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
             settingsIntent.setData(Uri.parse("package:" + packageName));
-            diagnostic.logDebug("Switch to notification Settings: Only possible on android O or above");
+            diagnostic.logDebug("Switch to notification Settings: Only possible on android O or above. Falling back to application details");
         }
         cordova.getActivity().startActivity(settingsIntent);
     }

--- a/src/android/Diagnostic_Notifications.java
+++ b/src/android/Diagnostic_Notifications.java
@@ -22,7 +22,12 @@ package cordova.plugins;
  * Imports
  */
 
+import android.content.Context;
+import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.net.Uri;
+import android.os.Build;
+import android.provider.Settings;
 import android.util.Log;
 
 import org.apache.cordova.CallbackContext;
@@ -107,6 +112,9 @@ public class Diagnostic_Notifications extends CordovaPlugin{
         try {
             if(action.equals("isRemoteNotificationsEnabled")) {
                 callbackContext.success(isRemoteNotificationsEnabled() ? 1 : 0);
+            } else if(action.equals("switchToNotificationSettings")) {
+                switchToNotificationSettings();
+                callbackContext.success();
             } else {
                 diagnostic.handleError("Invalid action");
                 return false;
@@ -125,6 +133,21 @@ public class Diagnostic_Notifications extends CordovaPlugin{
         return result;
     }
 
+    public void switchToNotificationSettings() {
+        Context context = this.cordova.getActivity().getApplicationContext();
+        Intent settingsIntent = new Intent();
+        String packageName = context.getPackageName();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            diagnostic.logDebug("Switch to notification Settings");
+            settingsIntent.setAction(Settings.ACTION_APP_NOTIFICATION_SETTINGS);
+            settingsIntent.putExtra(Settings.EXTRA_APP_PACKAGE, packageName);
+        } else {
+            settingsIntent.setAction(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
+            settingsIntent.setData(Uri.parse("package:" + packageName));
+            diagnostic.logDebug("Switch to notification Settings: Only possible on android O or above");
+        }
+        cordova.getActivity().startActivity(settingsIntent);
+    }
 
     /************
      * Internals

--- a/www/android/diagnostic.js
+++ b/www/android/diagnostic.js
@@ -1040,6 +1040,17 @@ var Diagnostic = (function(){
         }
     };
 
+    /**
+     * Switches to the notification settings page in the Settings app
+     */
+    Diagnostic.switchToNotificationSettings = function() {
+        if(cordova.plugins.diagnostic.notifications){
+            cordova.plugins.diagnostic.notifications.switchToNotificationSettings.apply(this, arguments);
+        }else{
+            throw "Diagnostic notification module is not installed";
+        }
+    };
+
 
     /***************************
      * Microphone / Record Audio

--- a/www/android/diagnostic.js
+++ b/www/android/diagnostic.js
@@ -1044,9 +1044,9 @@ var Diagnostic = (function(){
      * Switches to the notification settings page in the Settings app
      */
     Diagnostic.switchToNotificationSettings = function() {
-        if(cordova.plugins.diagnostic.notifications){
+        if (cordova.plugins.diagnostic.notifications){
             cordova.plugins.diagnostic.notifications.switchToNotificationSettings.apply(this, arguments);
-        }else{
+        } else {
             throw "Diagnostic notification module is not installed";
         }
     };

--- a/www/android/diagnostic.notifications.js
+++ b/www/android/diagnostic.notifications.js
@@ -58,6 +58,17 @@ var Diagnostic_Notifications = (function(){
             []);
     };
 
+    /**
+     * Switches to the notifications page in the Settings app
+     */
+    Diagnostic_Notifications.switchToNotificationSettings = function() {
+        return cordova.exec(null,
+            null,
+            'Diagnostic_Notifications',
+            'switchToNotificationSettings',
+            []);
+    };
+
     return Diagnostic_Notifications;
 });
 module.exports = new Diagnostic_Notifications();


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

<!-- Fill out the relevant sections below and delete irrelevant sections. -->

## PR Checklist
For bug fixes / features, please check if your PR fulfills the following requirements:

- [x] Testing has been carried out for the changes have been added
- [x] Regression testing has been carried out for existing functionality
- [x] Docs have been added / updated

## What is the purpose of this PR?
Add possibility to open notification settings on android devices running Android O or above. Android versions lower than O will fall back to just the app details page. Requested in issue #351.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## What testing has been done on the changes in the PR?
Added function has been tested on different Android versions

## What testing has been done on existing functionality?
Existing features were tested to be still working
