### PR TITLE
Added missing notification permission statuses, Provisional and Ephemeral

### DIFF
--- a/src/ios/Diagnostic.h
+++ b/src/ios/Diagnostic.h
@@ -20,6 +20,8 @@ extern NSString*const UNKNOWN;
 extern NSString*const AUTHORIZATION_NOT_DETERMINED;
 extern NSString*const AUTHORIZATION_DENIED;
 extern NSString*const AUTHORIZATION_GRANTED;
+extern NSString*const AUTHORIZATION_PROVISIONAL;
+extern NSString*const AUTHORIZATION_EPHEMERAL;
 
 @interface Diagnostic : CDVPlugin
 

--- a/src/ios/Diagnostic.m
+++ b/src/ios/Diagnostic.m
@@ -16,6 +16,8 @@ NSString*const UNKNOWN = @"unknown";
 NSString*const AUTHORIZATION_NOT_DETERMINED = @"not_determined";
 NSString*const AUTHORIZATION_DENIED = @"denied_always";
 NSString*const AUTHORIZATION_GRANTED = @"authorized";
+NSString*const AUTHORIZATION_PROVISIONAL = @"provisional";
+NSString*const AUTHORIZATION_EPHEMERAL = @"ephemeral";
 
 // Internal constants
 static NSString*const LOG_TAG = @"Diagnostic[native]";

--- a/src/ios/Diagnostic_Notifications.m
+++ b/src/ios/Diagnostic_Notifications.m
@@ -122,6 +122,14 @@ static NSString*const REMOTE_NOTIFICATIONS_BADGE = @"badge";
                     status = AUTHORIZATION_NOT_DETERMINED;
                 }else if(authStatus == UNAuthorizationStatusAuthorized){
                     status = AUTHORIZATION_GRANTED;
+                }else if(@available(iOS 12.0, *)) {
+                    if(authStatus == UNAuthorizationStatusProvisional) {
+                        status = AUTHORIZATION_PROVISIONAL;
+                    }
+                }else if (@available(iOS 14.0, *)) {
+                    if(authStatus == UNAuthorizationStatusEphemeral) {
+                        status = AUTHORIZATION_EPHEMERAL;
+                    }
                 }
                 [diagnostic logDebug:[NSString stringWithFormat:@"Remote notifications authorization status is: %@", status]];
                 [diagnostic sendPluginResultString:status:command];


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- [X] Bugfix
- [X] Feature
- [X] Documentation  changes

## PR Checklist
For bug fixes / features, please check if your PR fulfills the following requirements:

- [ ] Testing has been carried out for the changes have been added
- [ ] Regression testing has been carried out for existing functionality
- [ ] Docs have been added / updated

## What is the purpose of this PR?

At the moment this plugin doesn't deal with two new Notification Permissions statuses that have been added to iOS in v12 ("Provisional") and v14 ("Ephemeral"). 

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## What testing has been done on the changes in the PR?
Not done yet

## What testing has been done on existing functionality?
Not done yet

## Other information

- Still need to update docs
- Still need to update notification permission request function