### PR TITLE
Android 12.0 - API 31 - combineLocationStatuses() Fixes #456

### DIFF
--- a/www/android/diagnostic.location.js
+++ b/www/android/diagnostic.location.js
@@ -44,18 +44,18 @@ var Diagnostic_Location = (function(){
     function combineLocationStatuses(statuses){
         var coarseStatus = statuses[Diagnostic.permission.ACCESS_COARSE_LOCATION],
             fineStatus = statuses[Diagnostic.permission.ACCESS_FINE_LOCATION],
-            backgroundStatus = statuses[Diagnostic.permission.ACCESS_BACKGROUND_LOCATION],
+            backgroundStatus = statuses[Diagnostic.permission.ACCESS_BACKGROUND_LOCATION] || false,
             status;
 
-        if(coarseStatus === Diagnostic.permissionStatus.DENIED_ALWAYS || fineStatus === Diagnostic.permissionStatus.DENIED_ALWAYS){
-            status = Diagnostic.permissionStatus.DENIED_ALWAYS;
+        if(coarseStatus === Diagnostic.permissionStatus.GRANTED || fineStatus === Diagnostic.permissionStatus.GRANTED){
+            status = Diagnostic.permissionStatus.GRANTED;
         }else if(coarseStatus === Diagnostic.permissionStatus.DENIED_ONCE || fineStatus === Diagnostic.permissionStatus.DENIED_ONCE){
             status = Diagnostic.permissionStatus.DENIED_ONCE;
+        }else if(coarseStatus === Diagnostic.permissionStatus.DENIED_ALWAYS || fineStatus === Diagnostic.permissionStatus.DENIED_ALWAYS){
+            status = Diagnostic.permissionStatus.DENIED_ALWAYS;
         }else if(coarseStatus === Diagnostic.permissionStatus.NOT_REQUESTED || fineStatus === Diagnostic.permissionStatus.NOT_REQUESTED){
             status = Diagnostic.permissionStatus.NOT_REQUESTED;
-        }else if(typeof backgroundStatus === 'undefined' || backgroundStatus === Diagnostic.permissionStatus.GRANTED){
-            status = Diagnostic.permissionStatus.GRANTED;
-        }else{
+        }else if(backgroundStatus !== Diagnostic.permissionStatus.GRANTED){
             status = Diagnostic.permissionStatus.GRANTED_WHEN_IN_USE;
         }
         return status;


### PR DESCRIPTION
On allow "When in use" (approx location)
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix

<!-- Fill out the relevant sections below and delete irrelevant sections. -->

## PR Checklist
For bug fixes / features, please check if your PR fulfills the following requirements:

- [x] Testing has been carried out for the changes have been added
- [x] Regression testing has been carried out for existing functionality
- [ ] Docs have been added / updated

## What is the purpose of this PR?
When `ACCESS_COARSE_LOCATION is GRANTED` by the user but `ACCESS_FINE_LOCATION is `DENIED_ALWAYS`, `getLocationAuthorizationStatus()` will return `DENIED_ALWAYS`.   

This PR will not return `DENIED_ALWAYS` when interpreting the result of the Location Statuses. If one of the status is `GRANTED` it will continue to evaluate the subsequent if/else statements. 

This PR is (especially) relevant for Android 12 as the user is now by default presented with a choice between the two `GRANT` types when `requestLocationAuthorization()` is called. See issue #456.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
