### PR TITLE
Updated Android Location module to use LocationManager instead of Set…

### DIFF
--- a/src/android/Diagnostic_Location.java
+++ b/src/android/Diagnostic_Location.java
@@ -271,9 +271,9 @@ public class Diagnostic_Location extends CordovaPlugin{
      */
     private int getLocationMode() throws Exception {
         int mode;
-        if (Build.VERSION.SDK_INT >= 19){ // Kitkat and above
+        if (Build.VERSION.SDK_INT >= 19 && Build.VERSION.SDK_INT < 28){ // Kitkat to Oreo, Settings.Secute.LOCATION_MODE was deprecated in Pie (https://developer.android.com/reference/android/provider/Settings.Secure#LOCATION_MODE)
             mode = Settings.Secure.getInt(this.cordova.getActivity().getContentResolver(), Settings.Secure.LOCATION_MODE);
-        }else{ // Pre-Kitkat
+        }else{ // Pre-Kitkat and post-Oreo
             if(isLocationProviderEnabled(LocationManager.GPS_PROVIDER) && isLocationProviderEnabled(LocationManager.NETWORK_PROVIDER)){
                 mode = 3;
             } else if(isLocationProviderEnabled(LocationManager.GPS_PROVIDER)){


### PR DESCRIPTION
…tings.Secure.LOCATION_MODE for APIs 28 and higher.

Settings.Secure.LOCATION_MODE was deprecated in API 28 - https://developer.android.com/reference/android/provider/Settings.Secure#LOCATION_MODE

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

<!-- Fill out the relevant sections below and delete irrelevant sections. -->

## PR Checklist
For bug fixes / features, please check if your PR fulfills the following requirements:

- [x] Testing has been carried out for the changes have been added
- [x] Regression testing has been carried out for existing functionality
- [ ] Docs have been added / updated

## What is the purpose of this PR?
<!-- Describe any current behavior that you are modifying, or link to a relevant issue. -->
https://github.com/dpa99c/cordova-diagnostic-plugin/issues/449
<!-- Describe the new behavior added/modified and its purpose. -->
Added check to condition that decides between using Settings.Secure and LocationManager. API levels Kitkat to Oreo will use Settings.Secure. API levels pre-Kitkat and post-Oreo will use LocationManager.
These changes only apply to Android.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing plugin versions. -->

## What testing has been done on the changes in the PR?
<!-- e.g. if an example project exists for this plugin, has it been updated to test the new functionality? -->
Tested new changes on...

- Android 11 Physical Device
- Android 10 Physical Device
- API 24 Virtual Device

Tests included...

- What happened when app was denied permission?
- What happened when app was granted permission?
- What happened when location services was disabled?
- What happened when high accuracy settings was disabled?

## What testing has been done on existing functionality?
<!-- e.g. if an example project exists for this plugin, has been it been tested to ensure no regression bugs have been introduced? -->

Same as the tests case for "What testing has been done on the changes in the PR?"

## Other information
Important note regarding location accuracy settings.

On the Android 11 and 10 Physical Devices, there was 2 groups of location accuracy settings, as highlighted with black rectangles, "Improve accuracy" and "Google Location Accuracy":
![Screenshot_20220518-155022_Settings](https://user-images.githubusercontent.com/32340239/169136235-cd4dfa81-850b-41cd-bb98-3c08932abe12.jpg)


The "Improve accuracy" settings contains 2 toggle-able options, "Wi-Fi Scanning" and "Bluetooth Scanning".
These options did not appear to have any effect on the code. Regardless of whether they are enabled or disabled, the LocationManager.NETWORK_PROVIDER was reporting as enabled.

The Google Location Accuracy did have effects on the code. If Google Location Accuracy is disabled, NETWORK_PROVIDER was reported as disabled. If Google Location Accuracy is enabled, NETWORK_PROVIDER was reported as enabled.

I suspect that on Android devices that use google services, NETWORK_PROVIDER will map to Google Location Accuracy. If there are any Android devices that do not use google services, then I suspect NETWORK_PROVIDER will map to "Improve accuracy". With that said I am not entirely certain and am not entirely sure why "Improve accuracy" is disabled.

Luckily, I believe that basically all Android devices use google services. Still it is important to note so that any developers using the plugin don't mistake the two difference settings and then get confused when things don't work.