### PR TITLE
fix: android getExternalSdCardDetails on API 33

### DIFF
--- a/src/android/Diagnostic_External_Storage.java
+++ b/src/android/Diagnostic_External_Storage.java
@@ -136,11 +136,15 @@ public class Diagnostic_External_Storage extends CordovaPlugin{
      ***********/
 
     protected void getExternalSdCardDetails() throws Exception{
-        String permission = diagnostic.permissionsMap.get(externalStoragePermission);
-        if (diagnostic.hasRuntimePermission(permission)) {
+        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             _getExternalSdCardDetails();
         } else {
-            diagnostic.requestRuntimePermission(permission, Diagnostic.GET_EXTERNAL_SD_CARD_DETAILS_PERMISSION_REQUEST);
+            String permission = diagnostic.permissionsMap.get(externalStoragePermission);
+            if (diagnostic.hasRuntimePermission(permission)) {
+                _getExternalSdCardDetails();
+            } else {
+                diagnostic.requestRuntimePermission(permission, Diagnostic.GET_EXTERNAL_SD_CARD_DETAILS_PERMISSION_REQUEST);
+            }
         }
     }
 


### PR DESCRIPTION
android getExternalSdCardDetails on API 33 fails as the read/write external storage permissions have been removed.

Update to use the existing permissions check for API < 33, do not request the invalid permissions for API 33+

Backward compatible, non-breaking change.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

<!-- Fill out the relevant sections below and delete irrelevant sections. -->

## PR Checklist
For bug fixes / features, please check if your PR fulfills the following requirements:

- [X ] Testing has been carried out for the changes have been added
- [ ] Regression testing has been carried out for existing functionality
- [ ] Docs have been added / updated

## What is the purpose of this PR?
<!-- Describe any current behavior that you are modifying, or link to a relevant issue. -->
<!-- Describe the new behaviour added/modified and its purpose. -->

## Does this PR introduce a breaking change?
- [ ] Yes
- [ X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing plugin versions. -->

## What testing has been done on the changes in the PR?
<!-- e.g. if an example project exists for this plugin, has it been updated to test the new functionality? -->
Tested extensively on my own projects with different API versions to validate behaviour on API below 33 and on API 33+

## What testing has been done on existing functionality?
<!-- e.g. if an example project exists for this plugin, has been it been tested to ensure no regression bugs have been introduced? -->
No changes to existing behaviour

## Other information