### PR TITLE
Android: direct getExternalSdCardDetails without permission request

### DIFF
--- a/README.md
+++ b/README.md
@@ -3653,8 +3653,6 @@ Whereas this method returns:
 
 which are on external removable storage.
 
-- Requires permission for `READ_EXTERNAL_STORAGE` run-time permission which must be added to `AndroidManifest.xml`.
-
 ```
 cordova.plugins.diagnostic.getExternalSdCardDetails(successCallback, errorCallback);
 ```

--- a/README.md
+++ b/README.md
@@ -3535,7 +3535,7 @@ Checks if the application is authorized to use external storage.
 
 Notes for Android:
 - This is intended for Android 6 / API 23 and above. Calling on Android 5.1 / API 22 and below will always return TRUE as permissions are already granted at installation time.
-- This checks for `READ_EXTERNAL_STORAGE` `CAMERA` run-time permission.
+- This checks for `READ_EXTERNAL_STORAGE` run-time permission.
 
 ```
 cordova.plugins.diagnostic.isExternalStorageAuthorized(successCallback, errorCallback);
@@ -3669,7 +3669,7 @@ Each array entry is an object with the following keys:
     - {String} path - absolute path to the storage location
     - {String} filePath - absolute path prefixed with file protocol for use with cordova-plugin-file
     - {Boolean} canWrite - true if the location is writable
-    - {Integer} freeSpace - number of bytes of free space on the device on which the storage locaiton is mounted.
+    - {Integer} freeSpace - number of bytes of free space on the device on which the storage location is mounted.
     - {String} type - indicates the type of storage location: either "application" if the path is an Android application sandbox path or "root" if the path is the device root.
 - {Function} errorCallback -  The callback which will be called when operation encounters an error.
 The function is passed a single string parameter containing the error message.

--- a/src/android/Diagnostic.java
+++ b/src/android/Diagnostic.java
@@ -184,9 +184,6 @@ public class Diagnostic extends CordovaPlugin{
     public static final String CPU_ARCH_MIPS = "MIPS";
     public static final String CPU_ARCH_MIPS_64 = "MIPS_64";
 
-    protected static final String externalStorageClassName = "cordova.plugins.Diagnostic_External_Storage";
-    protected static final Integer GET_EXTERNAL_SD_CARD_DETAILS_PERMISSION_REQUEST = 1000;
-
     /*************
      * Variables *
      *************/
@@ -965,17 +962,7 @@ public class Diagnostic extends CordovaPlugin{
                 clearRequest(requestCode);
             }
 
-            Class<?> externalStorageClass = null;
-            try {
-                externalStorageClass = Class.forName(externalStorageClassName);
-            } catch( ClassNotFoundException e ){}
-
-            if(requestCode == GET_EXTERNAL_SD_CARD_DETAILS_PERMISSION_REQUEST && externalStorageClass != null){
-                Method method = externalStorageClass.getMethod("onReceivePermissionResult");
-                method.invoke(null);
-            }else{
-                context.success(statuses);
-            }
+            context.success(statuses);
         }catch(Exception e ) {
             handleError("Exception occurred onRequestPermissionsResult: ".concat(e.getMessage()), requestCode);
         }

--- a/src/android/Diagnostic_External_Storage.java
+++ b/src/android/Diagnostic_External_Storage.java
@@ -51,7 +51,6 @@ public class Diagnostic_External_Storage extends CordovaPlugin{
      * Constants *
      *************/
 
-
     /**
      * Tag for debug log messages
      */
@@ -73,8 +72,6 @@ public class Diagnostic_External_Storage extends CordovaPlugin{
      * Current Cordova callback context (on this thread)
      */
     protected CallbackContext currentContext;
-
-    protected static String externalStoragePermission = "READ_EXTERNAL_STORAGE";
 
 
     /*************
@@ -127,29 +124,12 @@ public class Diagnostic_External_Storage extends CordovaPlugin{
         return true;
     }
 
-    public static void onReceivePermissionResult() throws JSONException{
-        instance._getExternalSdCardDetails();
-    }
 
     /************
      * Internals
      ***********/
 
-    protected void getExternalSdCardDetails() throws Exception{
-        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            _getExternalSdCardDetails();
-        } else {
-            String permission = diagnostic.permissionsMap.get(externalStoragePermission);
-            if (diagnostic.hasRuntimePermission(permission)) {
-                _getExternalSdCardDetails();
-            } else {
-                diagnostic.requestRuntimePermission(permission, Diagnostic.GET_EXTERNAL_SD_CARD_DETAILS_PERMISSION_REQUEST);
-            }
-        }
-    }
-
-
-    protected void _getExternalSdCardDetails() throws JSONException {
+    protected void getExternalSdCardDetails() throws JSONException {
         String[] storageDirectories = getStorageDirectories();
 
         JSONArray details = new JSONArray();


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

<!-- Fill out the relevant sections below and delete irrelevant sections. -->

## PR Checklist
For bug fixes / features, please check if your PR fulfills the following requirements:

- [x] Testing has been carried out for the changes have been added
- [x] Regression testing has been carried out for existing functionality
- [x] Docs have been added / updated

## What is the purpose of this PR?
<!-- Describe any current behavior that you are modifying, or link to a relevant issue. -->
<!-- Describe the new behaviour added/modified and its purpose. -->
Listing the external SD cards is currently asking for permissions.
But the SDK 33 permission change made me look more into this, as asking for _MEDIA_ related permissions seems strange.
This permission request has been removed as tests confirm that all SD cards are correctly fetched without them in various Android versions.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing plugin versions. -->

## What testing has been done on the changes in the PR?
<!-- e.g. if an example project exists for this plugin, has it been updated to test the new functionality? -->

## What testing has been done on existing functionality?
<!-- e.g. if an example project exists for this plugin, has been it been tested to ensure no regression bugs have been introduced? -->
Built a testApp with targetSDK 33, installed on emulators API 28, 29, 30, 32, and 33,
Then I checked the SD cards listing is returning correct values, no error, and without asking for any permission.

## Other information
Tests done in the context of https://github.com/apache/cordova-plugin-file/pull/597.