### PR TITLE
Android: replace deprecated StatFs functions

### DIFF
--- a/src/android/Diagnostic_External_Storage.java
+++ b/src/android/Diagnostic_External_Storage.java
@@ -25,8 +25,9 @@ package cordova.plugins;
 import android.os.Build;
 import android.os.Environment;
 import android.os.StatFs;
-import androidx.core.os.EnvironmentCompat;
 import android.util.Log;
+
+import androidx.core.os.EnvironmentCompat;
 
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaInterface;
@@ -182,9 +183,7 @@ public class Diagnostic_External_Storage extends CordovaPlugin{
     protected long getFreeSpaceInBytes(String path) {
         try {
             StatFs stat = new StatFs(path);
-            long blockSize = stat.getBlockSize();
-            long availableBlocks = stat.getAvailableBlocks();
-            return availableBlocks * blockSize;
+            return stat.getAvailableBytes();
         } catch (IllegalArgumentException e) {
             // The path was invalid. Just return 0 free bytes.
             return 0;


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

<!-- Fill out the relevant sections below and delete irrelevant sections. -->

## PR Checklist
For bug fixes / features, please check if your PR fulfills the following requirements:

- [x] Testing has been carried out for the changes have been added
- [ ] Regression testing has been carried out for existing functionality
- [x] Docs have been added / updated

## What is the purpose of this PR?
<!-- Describe any current behavior that you are modifying, or link to a relevant issue. -->
[`getAvailableBlocks`](https://developer.android.com/reference/android/os/StatFs#getAvailableBlocks()) and [`getBlockSize`](https://developer.android.com/reference/android/os/StatFs#getBlockSize()) are deprecated since API 18
<!-- Describe the new behaviour added/modified and its purpose. -->
[`getAvailableBytes`](https://developer.android.com/reference/android/os/StatFs#getAvailableBytes()) is available since API 18
while current `cordova-android` must be [`>=8.0.0`](https://github.com/dpa99c/cordova-diagnostic-plugin/blob/master/plugin.xml#L14), so [minSdk 19](https://github.com/apache/cordova-android/blob/rel/8.0.0/framework/AndroidManifest.xml#L22)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing plugin versions. -->

## What testing has been done on the changes in the PR?
<!-- e.g. if an example project exists for this plugin, has it been updated to test the new functionality? -->

## What testing has been done on existing functionality?
<!-- e.g. if an example project exists for this plugin, has been it been tested to ensure no regression bugs have been introduced? -->

## Other information