### PR TITLE
Android: remove unused imports

### DIFF
--- a/src/android/Diagnostic.java
+++ b/src/android/Diagnostic.java
@@ -43,7 +43,6 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import android.Manifest;
-import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.AlarmManager;
 import android.app.PendingIntent;

--- a/src/android/Diagnostic_Camera.java
+++ b/src/android/Diagnostic_Camera.java
@@ -22,10 +22,8 @@ package cordova.plugins;
  * Imports
  */
 
-import android.Manifest;
 import android.content.pm.PackageManager;
 import android.hardware.Camera;
-import android.os.Build;
 import android.util.Log;
 
 import org.apache.cordova.CallbackContext;


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

<!-- Fill out the relevant sections below and delete irrelevant sections. -->

## What is the purpose of this PR?
<!-- Describe any current behavior that you are modifying, or link to a relevant issue. -->
<!-- Describe the new behaviour added/modified and its purpose. -->
Commit f5298057938b4e044ed9d57e3532d59e6cfa0920 added the `TargetApi` import, and then the commit 823f0a0e0c7cd43425e64c60f12b98f9f69cfc0a added the `Manifest` and `Build` imports, but all yet unused.
