### PR TITLE
Bump WRITE_EXTERNAL_STORAGE to 32 for camera

### DIFF
--- a/src/android/Diagnostic.java
+++ b/src/android/Diagnostic.java
@@ -187,7 +187,7 @@ public class Diagnostic extends CordovaPlugin{
         Map<String, Integer> _permissionsMap = new HashMap <String, Integer>();
 
         Diagnostic.addBiDirMapEntry(_permissionsMap, "READ_EXTERNAL_STORAGE", 32);
-        Diagnostic.addBiDirMapEntry(_permissionsMap, "WRITE_EXTERNAL_STORAGE", 29);
+        Diagnostic.addBiDirMapEntry(_permissionsMap, "WRITE_EXTERNAL_STORAGE", 32);
 
         maxSdkPermissionMap = Collections.unmodifiableMap(_permissionsMap);
     }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

## PR Checklist
For bug fixes / features, please check if your PR fulfills the following requirements:

- [x] Testing has been carried out for the changes have been added
- [x] Regression testing has been carried out for existing functionality
- [x] Docs have been added / updated

## What is the purpose of this PR?

requestCameraAuthorization in API 30 requests WRITE_EXTERNAL_STORAGE, however, if it has not already been granted, it fails because maxSdkPermissionMap was set to 29. This prevents new authorizations from being given for camera use in API 30. 

I increased it to 32 to allow all API < 33 to work.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## What testing has been done on the changes in the PR?

I have tested it on Android level 9, 11, 12, and 13.

## What testing has been done on existing functionality?

I used it to take a picture and otherwise exercise its functionality and nothing else seems to have changed.

## Other information