### PR TITLE
feat(ios): Resource Bundle to provide the Privacy Manifest

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -29,6 +29,8 @@
             <merges target="cordova.plugins.diagnostic" />
         </js-module>
 
+        <resource-file src="src/ios/Diagnostic_Resources.bundle" target="Diagnostic_Resources.bundle" />
+
         <header-file src="src/ios/Diagnostic.h" />
         <source-file src="src/ios/Diagnostic.m" />
 

--- a/src/ios/Diagnostic_Resources.bundle/PrivacyInfo.xcprivacy
+++ b/src/ios/Diagnostic_Resources.bundle/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSPrivacyTracking</key>
+    <false/>
+    <key>NSPrivacyTrackingDomains</key>
+    <array>
+    </array>
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array/>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array>
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>CA92.1</string>
+            </array>
+        </dict>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
No data is collected in accordance to Apple's definition of collected data.

https://developer.apple.com/app-store/app-privacy-details/#data-collection

“Collect” refers to transmitting data off the device in a way that allows you and/or your third-party partners to access it for a period longer than what is necessary to service the transmitted request in real time.

There is one API that requires a declared reason to use, the NSUserDefaults API. The code is in the base Diagnostic utility class so it's available/used regardless of modules instead, but the actual execution path is only ever invoked through the Motion module.

It uses the standard user defaults object which is private to the application. CA92.1 appears to the best reason description, which describes that the SDK reads and writes information that is only accessible by the app itself and not to other apps or processes.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [x] Other... Please describe: iOS Privacy Manifest Requirements

<!-- Fill out the relevant sections below and delete irrelevant sections. -->

## What is the purpose of this PR?
<!-- Describe any current behavior that you are modifying, or link to a relevant issue. -->
<!-- Describe the new behaviour added/modified and its purpose. -->

Adds a resource bundle which contains a privacy manifest declaring required parameters for this plugin. This in itself is not a breaking change, but does require XCode 15 to use. Older XCode versions will simply ignore privacy manifest files.

No actual code changes have been made.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing plugin versions. -->

## What testing has been done on the changes in the PR?

This pattern has been tested on several other apache plugins, including the [device plugin](https://github.com/apache/cordova-plugin-device/pull/193) and [file plugin](https://github.com/apache/cordova-plugin-file/pull/621).

<!-- e.g. if an example project exists for this plugin, has it been updated to test the new functionality? -->

## What testing has been done on existing functionality?
<!-- e.g. if an example project exists for this plugin, has been it been tested to ensure no regression bugs have been introduced? -->

## Other information

`CA92.1` is a [Apple code](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api?language=objc) which stands for:


>Declare this reason to access user defaults to read and write information that is only accessible to the app itself.
>
>This reason does not permit reading information that was written by other apps or the system, or writing information that can be accessed by other apps.
