### PR TITLE
Added iOS implementation of switchToNotificationSettings function

### DIFF
--- a/README.md
+++ b/README.md
@@ -2689,11 +2689,11 @@ Requests remote notifications authorization for the application.
 
 ### switchToNotificationSettings()
 
-Platforms: Android
+Platforms: Android & iOS
 
 Open notification settings for your app
 
-On Android versions lower than O, this will open the same page as `switchToSettings()`.
+On Android versions lower than O and on iOS versions lower than 15.4, this will open the same page as `switchToSettings()`.
 
     cordova.plugins.diagnostic.switchToNotificationSettings();
 

--- a/cordova.plugins.diagnostic.d.ts
+++ b/cordova.plugins.diagnostic.d.ts
@@ -1016,6 +1016,14 @@ interface Diagnostic {
     ) => void;
 
     /**
+     * Opens the notification settings page for this app.
+     */
+    switchToNotificationSettings?: (
+        successCallback: () => void,
+        errorCallback: (error: string) => void
+    ) => void;
+
+    /**
      * ANDROID ONLY
      * Checks if ADB mode(debug mode) is enabled.
      * @param successCallback

--- a/src/ios/Diagnostic_Notifications.h
+++ b/src/ios/Diagnostic_Notifications.h
@@ -18,5 +18,6 @@
 - (void) isRegisteredForRemoteNotifications: (CDVInvokedUrlCommand*)command;
 - (void) getRemoteNotificationsAuthorizationStatus: (CDVInvokedUrlCommand*)command;
 - (void) requestRemoteNotificationsAuthorization: (CDVInvokedUrlCommand*)command;
+- (void) switchToNotificationSettings: (CDVInvokedUrlCommand*)command;
 
 @end

--- a/src/ios/Diagnostic_Notifications.m
+++ b/src/ios/Diagnostic_Notifications.m
@@ -223,6 +223,32 @@ static NSString*const REMOTE_NOTIFICATIONS_BADGE = @"badge";
     }];
 }
 
+- (void) switchToNotificationSettings: (CDVInvokedUrlCommand*)command
+{
+    @try {
+        if (@available(iOS 15.4, *)) {
+            [[UIApplication sharedApplication] openURL:[NSURL URLWithString: UIApplicationOpenNotificationSettingsURLString] options:@{} completionHandler:^(BOOL success) {
+                if (success) {
+                    [diagnostic sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK] :command];
+                }else{
+                    [diagnostic sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR] :command];
+                }
+            }];
+        } else { 
+            [[UIApplication sharedApplication] openURL:[NSURL URLWithString: UIApplicationOpenSettingsURLString] options:@{} completionHandler:^(BOOL success) {
+                if (success) {
+                    [diagnostic sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK] :command];
+                }else{
+                    [diagnostic sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR] :command];
+                }
+            }];
+        }
+    }
+    @catch (NSException *exception) {
+        [diagnostic handlePluginException:exception :command];
+    }
+}
+
 - (void) _isRegisteredForRemoteNotifications:(void (^)(BOOL result))completeBlock {
     dispatch_async(dispatch_get_main_queue(), ^{
         BOOL registered = [UIApplication sharedApplication].isRegisteredForRemoteNotifications;

--- a/www/ios/diagnostic.js
+++ b/www/ios/diagnostic.js
@@ -696,6 +696,21 @@ var Diagnostic = (function(){
     };
 
     /**
+     * Switches to the notification settings page in the Settings app
+     * 
+     * @param {Function} successCallback - The callback which will be called when switch to settings is successful.
+     * @param {Function} errorCallback - The callback which will be called when switch to settings encounters an error.
+     * This callback function is passed a single string parameter containing the error message.
+     */
+    Diagnostic.switchToNotificationSettings = function(successCallback, errorCallback) {
+        if (cordova.plugins.diagnostic.notifications){
+            cordova.plugins.diagnostic.notifications.switchToNotificationSettings.apply(this, arguments);
+        } else {
+            throw "Diagnostic Notification module is not installed";
+        }
+    };
+
+    /**
      * Indicates the current setting of notification types for the app in the Settings app.
      * Note: if "Allow Notifications" switch is OFF, all types will be returned as disabled.
      *

--- a/www/ios/diagnostic.notifications.js
+++ b/www/ios/diagnostic.notifications.js
@@ -183,6 +183,17 @@ var Diagnostic_Notifications = (function(){
             [params.types, params.omitRegistration ? 1 : 0]);
     };
 
+    /**
+     * Switches to the notifications page in the Settings app
+     */
+    Diagnostic_Notifications.switchToNotificationSettings = function(successCallback, errorCallback) {
+        return cordova.exec(successCallback,
+            errorCallback,
+            'Diagnostic_Notifications',
+            'switchToNotificationSettings',
+            []);
+    };
+
 
     return Diagnostic_Notifications;
 });


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Documentation  changes
- [ ] Other... Please describe:

## PR Checklist
For bug fixes / features, please check if your PR fulfils the following requirements:

- [x] Testing has been carried out for the changes have been added
- [x] Regression testing has been carried out for existing functionality
- [x] Docs have been added / updated

## What is the purpose of this PR?
I have implemented the iOS platform functionality for the existing `switchToNotificationSettings` function in the Notifications module, currently only available on Android. On iOS 15.4 or below, the native API to do this was not available, so instead similar to the android implementation, it will take you to the general app settings page instead.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## What testing has been done on the changes in the PR?
An existing project of mine required the function on both platforms. I have tested it on devices both above and below iOS 15.4.

## What testing has been done on existing functionality?
I have have made sure the original android function had not been affected, as I require both for my project.