### PR TITLE
Added conditions to not use CTCellularData on Mac Catalyst.

### DIFF
--- a/src/ios/Diagnostic.m
+++ b/src/ios/Diagnostic.m
@@ -7,7 +7,10 @@
  */
 
 #import "Diagnostic.h"
+// Only import the following header if we're not on Mac Catalyst
+#if !TARGET_OS_MACCATALYST
 #import <CoreTelephony/CTCellularData.h>
+#endif
 
 @implementation Diagnostic
 
@@ -32,7 +35,11 @@ static NSString*const CPU_ARCH_X86_64 = @"X86_64";
 
 // Internal properties
 static Diagnostic* diagnostic = nil;
+
+// Only if not on Mac Catalyst
+#if !TARGET_OS_MACCATALYST
 static CTCellularData* cellularData;
+#endif
 
 /********************************/
 #pragma mark - Public static functions
@@ -114,7 +121,11 @@ static CTCellularData* cellularData;
 
     self.debugEnabled = false;
     self.osVersion = [[[UIDevice currentDevice] systemVersion] floatValue];
-    cellularData = [[CTCellularData alloc] init];
+
+    // Only if not on Mac Catalyst
+    #if !TARGET_OS_MACCATALYST
+        cellularData = [[CTCellularData alloc] init];
+    #endif
 }
 
 // https://stackoverflow.com/a/38441011/777265
@@ -220,8 +231,14 @@ static CTCellularData* cellularData;
 {
     [self.commandDelegate runInBackground:^{
         @try {
-            bool isEnabled = cellularData.restrictedState == kCTCellularDataNotRestricted;;
-            [diagnostic sendPluginResultBool:isEnabled :command];
+            #if !TARGET_OS_MACCATALYST
+                bool isEnabled = cellularData.restrictedState == kCTCellularDataNotRestricted;;
+                [diagnostic sendPluginResultBool:isEnabled :command];
+            // If we're on Mac Catalyst, set this always to false
+            #else
+                [diagnostic sendPluginResultBool:false :command];
+                return;
+            #endif
         }
         @catch (NSException *exception) {
             [diagnostic handlePluginException:exception :command];


### PR DESCRIPTION
## PR Type
This PR adds code to check if we're compiling for Mac Catalyst and then disables usage of the CTCellularData module, which is not available on macOS.

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

## PR Checklist
For bug fixes / features, please check if your PR fulfills the following requirements:

- [x] Testing has been carried out for the changes have been added
- [ ] Regression testing has been carried out for existing functionality
- [ ] Docs have been added / updated

## What is the purpose of this PR?
Currently apps with this plugin will not build on Mac Catalyst due to the use of CoreTelephony/CTCelluarData, which is not available on macOS. With this change, code will be wrapped in conditions to check for this target and will thus be excluded from Mac Catalyst.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No