### PR TITLE
fix(Diagnostic_Bluethooth.java): Value null at 0 of type org.json.JSO…

### DIFF
--- a/src/android/Diagnostic_Bluetooth.java
+++ b/src/android/Diagnostic_Bluetooth.java
@@ -327,7 +327,7 @@ public class Diagnostic_Bluetooth extends CordovaPlugin {
 
     public void requestBluetoothAuthorization(JSONArray args, CallbackContext callbackContext) throws Exception {
         JSONArray permissionsToRequest = new JSONArray();
-        if(args.length() > 0){
+        if(args.length() > 0 && args.get(0) instanceof JSONArray){
             JSONArray specifiedPermissions = args.getJSONArray(0);
             if(specifiedPermissions.length() > 0){
                 for (int i = 0, size = specifiedPermissions.length(); i < size; i++){


### PR DESCRIPTION
Value null at 0 of type org.json.JSONObject$1 cannot be converted to JSONArray

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

<!-- Fill out the relevant sections below and delete irrelevant sections. -->

## PR Checklist
For bug fixes / features, please check if your PR fulfills the following requirements:

- [x] Testing has been carried out for the changes have been added
- [ ] Regression testing has been carried out for existing functionality
- [ ] Docs have been added / updated

## What is the purpose of this PR?
The requestBluetoothAutorization method in Android is causing an exception because args[0] is null instead of a expected JSONAarray, so i added an extra check and no it shows the res object properly

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## What testing has been done on the changes in the PR?
I tested it by modifying the file inside my node_modules folder and recompiling my project. I also forked the repo, did the fix and installed the forked version of the plugin in my project.
 
 
![image](https://github.com/user-attachments/assets/43c5f784-8b64-48a5-b0df-74522ecea60a)
![image](https://github.com/user-attachments/assets/493b341a-0eae-4aca-87a8-2a5a8a763581)
