### PR TITLE
docs: update getCameraRollAuthorizationStatus example to include accessLevel parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -2498,7 +2498,7 @@ Platforms: iOS
 
 Returns the authorization status for the application to use the Camera Roll in Photos app.
 
-    cordova.plugins.diagnostic.getCameraRollAuthorizationStatus(successCallback, errorCallback);
+    cordova.plugins.diagnostic.getCameraRollAuthorizationStatus(successCallback, errorCallback, accessLevel);
 
 #### Parameters
 


### PR DESCRIPTION
## PR Type
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Documentation  changes
- [ ] Other... Please describe:

<!-- Fill out the relevant sections below and delete irrelevant sections. -->

## PR Checklist
- [ ] Testing has been carried out for the changes have been added
- [ ] Regression testing has been carried out for existing functionality
- [x] Docs have been added / updated

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documentation for the camera authorization status method to include an optional parameter for specifying access level on supported iOS versions.
  * Example usage and method signature now reflect the new optional parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->