### PR TITLE
fix(iOS): Synchronize Bluetooth manager initialization to ensure thread safety

### DIFF
--- a/src/ios/Diagnostic_Bluetooth.m
+++ b/src/ios/Diagnostic_Bluetooth.m
@@ -156,12 +156,14 @@ static NSString*const LOG_TAG = @"Diagnostic_Bluetooth[native]";
 }
 
 - (void) ensureBluetoothManager {
-    if(![self.bluetoothManager isKindOfClass:[CBCentralManager class]]){
+    @synchronized(self) {
+      if(![self.bluetoothManager isKindOfClass:[CBCentralManager class]]){
         self.bluetoothManager = [[CBCentralManager alloc]
                                  initWithDelegate:self
                                  queue:dispatch_get_main_queue()
                                  options:@{CBCentralManagerOptionShowPowerAlertKey: @(NO)}];
         [self centralManagerDidUpdateState:self.bluetoothManager]; // Send initial state
+      }
     }
 }
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

<!-- Fill out the relevant sections below and delete irrelevant sections. -->

## PR Checklist
For bug fixes / features, please check if your PR fulfills the following requirements:

- [x] Testing has been carried out for the changes have been added
- [ ] Regression testing has been carried out for existing functionality
- [ ] Docs have been added / updated

## What is the purpose of this PR?
This PR addresses recurring crashes related to the Bluetooth manager initialization.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing plugin versions. -->

## What testing has been done on the changes in the PR?
I forked the repository, applied the fix, and locally tested on iPhone 14 (iOS 26) verifing the core API of the Bluetooth module in my own project. I also reviewed Firebase Crashlytics data after releasing the patched plugin version. Since the rollout, crashes related to the Bluetooth manager have no longer appeared.

## Other information
In my project, I had been seeing recurring crashes related to the Bluetooth module over the past few versions. A representative crash looked like this:
```
 Crashed: com.apple.root.default-qos
0  libobjc.A.dylib                0x1b3c objc_release + 8
1  libobjc.A.dylib                0x1b3c objc_release_x0 + 8
2  thing-it Mobile                0x13c4c -[Diagnostic_Bluetooth ensureBluetoothManager] + 160 (Diagnostic_Bluetooth.m:160)
3  thing-it Mobile                0x13ad4 -[Diagnostic_Bluetooth getBluetoothState] + 120 (Diagnostic_Bluetooth.m:120)
4  thing-it Mobile                0x13594 __42-[Diagnostic_Bluetooth getBluetoothState:]_block_invoke + 53 (Diagnostic_Bluetooth.m:53)
5  libdispatch.dylib              0x1adc _dispatch_call_block_and_release + 32
6  libdispatch.dylib              0x1b7fc _dispatch_client_callout + 16
7  libdispatch.dylib              0x377e4 _dispatch_queue_override_invoke.cold.3 + 32
8  libdispatch.dylib              0x62fc _dispatch_queue_override_invoke + 848
9  libdispatch.dylib              0x13f48 _dispatch_root_queue_drain + 364
10 libdispatch.dylib              0x146fc _dispatch_worker_thread2 + 180
11 libsystem_pthread.dylib        0x137c _pthread_wqthread + 232
12 libsystem_pthread.dylib        0x8c0 start_wqthread + 8
```
Although I was not able to reproduce the issue locally, the stack trace suggested a potential threading problem during Bluetooth manager initialization. I assumed that one thread attempted to release the Bluetooth manager while another thread was still in the process of creating or configuring it. 
After applying the fix, the crash no longer appears in production according to Crashlytics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved stability and reliability of Bluetooth initialization on iOS to prevent potential concurrent access issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->