### PR TITLE
Fix requestCalendarAuthorization on iOS 17+

### DIFF
--- a/src/ios/Diagnostic_Calendar.m
+++ b/src/ios/Diagnostic_Calendar.m
@@ -75,10 +75,17 @@ static NSString*const LOG_TAG = @"Diagnostic_Calendar[native]";
                 self.eventStore = [EKEventStore new];
             }
 
-            [self.eventStore requestAccessToEntityType:EKEntityTypeEvent completion:^(BOOL granted, NSError *error) {
-                [diagnostic logDebug:[NSString stringWithFormat:@"Access request to calendar events: %d", granted]];
-                [diagnostic sendPluginResultBool:granted:command];
-            }];
+            if (@available(iOS 17.0, *)) {
+                [self.eventStore requestFullAccessToEventsWithCompletion:^(BOOL granted, NSError *error) {
+                    [diagnostic logDebug:[NSString stringWithFormat:@"Access request to calendar events: %d", granted]];
+                    [diagnostic sendPluginResultBool:granted:command];
+                }];
+            } else {
+                [self.eventStore requestAccessToEntityType:EKEntityTypeEvent completion:^(BOOL granted, NSError *error) {
+                    [diagnostic logDebug:[NSString stringWithFormat:@"Access request to calendar events: %d", granted]];
+                    [diagnostic sendPluginResultBool:granted:command];
+                }];
+            }
         }
         @catch (NSException *exception) {
             [diagnostic handlePluginException:exception :command];


### PR DESCRIPTION
## Summary

Fixes #512. On iOS 17+, `requestAccessToEntityType:completion:` is deprecated and no longer triggers the calendar permission dialog, causing `requestCalendarAuthorization()` to always return `DENIED_ALWAYS`.

This replaces it with `requestFullAccessToEventsWithCompletion:` when running on iOS 17+, using `@available(iOS 17.0, *)` to maintain backward compatibility with older versions.

## Changes

- `src/ios/Diagnostic_Calendar.m`: Use `requestFullAccessToEventsWithCompletion:` on iOS 17+, fall back to `requestAccessToEntityType:completion:` on older versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved iOS calendar authorization handling to utilize iOS 17+ native APIs when available, while maintaining backward compatibility with earlier iOS versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->