### PR TITLE
Fix apply-modules script compatibility with pnpm

### DIFF
--- a/scripts/apply-modules.js
+++ b/scripts/apply-modules.js
@@ -28,7 +28,7 @@ const COMMENT_START = "<!--";
 const COMMENT_END = "-->";
 
 // Node dependencies
-var path, cwd, fs;
+var path, fs;
 
 // External dependencies
 var et;
@@ -36,7 +36,7 @@ var et;
 // Internal dependencies
 var logger;
 
-var projectPath, modulesPath, pluginNodePath, pluginScriptsPath, configXmlPath, pluginXmlPath, configXmlData, pluginXmlText;
+var projectPath, pluginNodePath, pluginScriptsPath, configXmlPath, pluginXmlPath, configXmlData, pluginXmlText;
 
 
 /*********************
@@ -137,24 +137,44 @@ var getModuleEnd = function(module){
 /**********
  * Main
  **********/
+// Finds the project root by walking up from startDir looking for config.xml
+var findProjectRoot = function(startDir) {
+    var dir = startDir;
+    while (true) {
+        if (fs.existsSync(path.join(dir, 'config.xml'))) {
+            return dir;
+        }
+        var parent = path.dirname(dir);
+        if (parent === dir) {
+            // Reached filesystem root without finding config.xml
+            return null;
+        }
+        dir = parent;
+    }
+};
+
 var main = function() {
     try{
         fs = require('fs');
         path = require('path');
-        cwd = path.resolve();
-        pluginNodePath = cwd;
 
-        modulesPath = path.resolve(pluginNodePath, "..");
-        projectPath = path.resolve(modulesPath, "..");
-        pluginScriptsPath = path.resolve(pluginNodePath, "scripts");
+        // Use __dirname to reliably locate the plugin regardless of node_modules structure.
+        // This works with npm, yarn, and pnpm (which uses symlinked .pnpm store).
+        pluginNodePath = path.resolve(__dirname, "..");
+        pluginScriptsPath = __dirname;
 
-        logger = require(path.resolve(pluginScriptsPath, "logger.js"))(modulesPath, PLUGIN_ID);
-        et = require(path.resolve(modulesPath, "elementtree"));
+        logger = require(path.join(pluginScriptsPath, "logger.js"))(PLUGIN_ID);
+        et = require('elementtree');
     }catch(e){
         handleError("Failed to load dependencies. If using cordova@6 CLI, ensure this plugin is installed with the --fetch option or run 'npm install "+PLUGIN_ID+"': " + e.message);
     }
 
     try{
+        projectPath = findProjectRoot(pluginNodePath);
+        if (!projectPath) {
+            handleError("Could not find project root (no config.xml found in any parent directory)");
+            return;
+        }
         configXmlPath = path.join(projectPath, 'config.xml');
         pluginXmlPath = path.join(pluginNodePath, "plugin.xml");
         run();

--- a/scripts/logger.js
+++ b/scripts/logger.js
@@ -6,7 +6,7 @@ var logger = (function(){
      * Internal properties
      *********************/
     var logger, path, minimist,
-        modulesPath, pluginId, hasColors = true, cliArgs;
+        pluginId, hasColors = true, cliArgs;
 
     function prefixMsg(msg){
         return pluginId+": "+msg;
@@ -16,19 +16,16 @@ var logger = (function(){
      * Public API
      ************/
     logger = {
-        init: function(_modulesPath, _pluginId){
+        init: function(_pluginId){
             pluginId = _pluginId;
-            modulesPath = _modulesPath;
-
-            path = require('path');
 
             try{
-                require(path.resolve(modulesPath, "colors"));
+                require('colors');
             }catch(e){
                 hasColors = false;
             }
 
-            minimist = require(path.resolve(modulesPath, "minimist"));
+            minimist = require('minimist');
             cliArgs = minimist(process.argv.slice(2));
         },
         dump: function (obj){
@@ -88,7 +85,7 @@ var logger = (function(){
     return logger;
 })();
 
-module.exports = function(modulesPath, pluginId){
-    logger.init(modulesPath, pluginId);
+module.exports = function(pluginId){
+    logger.init(pluginId);
     return logger;
 };


### PR DESCRIPTION
Fixes #535

The `postinstall` script `apply-modules.js` hardcodes path assumptions (`../` = `node_modules`, `../../` = project root) that only hold for npm's flat `node_modules` layout. Under pnpm, the real package path is nested inside `.pnpm/` store, so those relative traversals resolve to wrong directories. This causes all modules to be applied regardless of `config.xml` preferences.

## Changes

**`scripts/apply-modules.js`**
- Use `__dirname` instead of `path.resolve()` (cwd) to locate the plugin root, which follows symlinks correctly under pnpm
- Use `require('elementtree')` instead of manual path resolution — Node's `require` respects the package's own `node_modules` regardless of linker strategy
- Find the project root by walking up the directory tree looking for `config.xml` instead of assuming it's exactly two levels up from the package

**`scripts/logger.js`**
- Use `require('colors')` and `require('minimist')` instead of resolving them via a `modulesPath` parameter
- Remove the now-unnecessary `modulesPath` parameter from the init/export signature

These changes are backwards-compatible with npm and yarn, which both resolve `__dirname` and `require()` identically to before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal module resolution and dependency loading mechanisms for improved stability
  * Enhanced project configuration detection to automatically locate and validate project setup files
  * Refactored internal module initialization to simplify dependency management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->